### PR TITLE
[MOOV-2034]: Added 'errors' prop to ApiError model

### DIFF
--- a/src/types/ApiResponses.ts
+++ b/src/types/ApiResponses.ts
@@ -141,6 +141,7 @@ export type ApiError = {
   title: string
   status?: number
   detail: string
+  errors?: { [key: string]: string[] }
 }
 
 export type ApiResponse<T> =


### PR DESCRIPTION
ApiError model was missing the dynamic 'errors' property to correctly display validation messages on-screen to the user.