### PR TITLE
Updated usePaymentRequest to get placeholder data from cache

### DIFF
--- a/src/hooks/useCapture.ts
+++ b/src/hooks/useCapture.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 import { UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ApiError } from '../types'
 import { PaymentRequestClient } from '../clients'
-import { ApiProps, CaptureProps } from '../types/props'
+import { ApiProps, CaptureProps, usePaymentRequestsProps } from '../types/props'
 
 const capture = async (
   apiUrl: string,
@@ -21,7 +21,23 @@ const capture = async (
 }
 
 export const useCapture = (
-  merchantId: string,
+  {
+    merchantId,
+    statusSortDirection,
+    createdSortDirection,
+    contactSortDirection,
+    amountSortDirection,
+    pageNumber,
+    pageSize,
+    fromDateMS,
+    toDateMS,
+    status,
+    search,
+    currency,
+    minAmount,
+    maxAmount,
+    tags,
+  }: usePaymentRequestsProps,
   { apiUrl, authToken }: ApiProps,
 ): {
   processCapture: (captureProps: CaptureProps) => Promise<{ error: ApiError | undefined }>
@@ -38,7 +54,28 @@ export const useCapture = (
     authToken,
   ]
 
-  // When this mutation succeeds, invalidate any queries with the single payment request query key
+  const PAYMENT_REQUESTS_QUERY_KEY = [
+    'PaymentRequests',
+    apiUrl,
+    authToken,
+    merchantId,
+    statusSortDirection,
+    createdSortDirection,
+    contactSortDirection,
+    amountSortDirection,
+    pageNumber,
+    pageSize,
+    fromDateMS,
+    toDateMS,
+    status,
+    search,
+    currency,
+    minAmount,
+    maxAmount,
+    tags,
+  ]
+
+  // When this mutation succeeds, invalidate any queries with the payment requests query key
   const mutation: UseMutationResult<
     { success?: boolean | undefined; error?: ApiError | undefined },
     Error,
@@ -55,6 +92,7 @@ export const useCapture = (
     onSuccess: (data: { success?: boolean | undefined; error?: ApiError | undefined }) => {
       if (data.success) {
         queryClient.invalidateQueries({ queryKey: SINGLE_PAYMENT_REQUEST_QUERY_KEY })
+        queryClient.invalidateQueries({ queryKey: PAYMENT_REQUESTS_QUERY_KEY })
       }
     },
   })

--- a/src/hooks/useCapture.ts
+++ b/src/hooks/useCapture.ts
@@ -1,0 +1,84 @@
+import { useCallback, useState } from 'react'
+import { UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query'
+import { ApiError } from '../types'
+import { PaymentRequestClient } from '../clients'
+import { ApiProps, CaptureProps } from '../types/props'
+
+const capture = async (
+  apiUrl: string,
+  authorizationId: string,
+  paymentRequestId: string,
+  authToken?: string,
+  amount?: number,
+): Promise<{
+  success?: boolean
+  error?: ApiError
+}> => {
+  const client = new PaymentRequestClient({ apiUrl, authToken })
+  const response = await client.captureCardPayment(paymentRequestId, authorizationId, amount)
+
+  return response
+}
+
+export const useCapture = (
+  merchantId: string,
+  { apiUrl, authToken }: ApiProps,
+): {
+  processCapture: (captureProps: CaptureProps) => Promise<{ error: ApiError | undefined }>
+} => {
+  const queryClient = useQueryClient()
+
+  const [paymentRequestID, setPaymentRequestID] = useState<string>()
+
+  const SINGLE_PAYMENT_REQUEST_QUERY_KEY = [
+    'PaymentRequest',
+    merchantId,
+    paymentRequestID,
+    apiUrl,
+    authToken,
+  ]
+
+  // When this mutation succeeds, invalidate any queries with the single payment request query key
+  const mutation: UseMutationResult<
+    { success?: boolean | undefined; error?: ApiError | undefined },
+    Error,
+    CaptureProps
+  > = useMutation({
+    mutationFn: (variables: CaptureProps) =>
+      capture(
+        apiUrl,
+        variables.authorizationId,
+        variables.paymentRequestId,
+        authToken,
+        variables.amount,
+      ),
+    onSuccess: (data: { success?: boolean | undefined; error?: ApiError | undefined }) => {
+      if (data.success) {
+        queryClient.invalidateQueries({ queryKey: SINGLE_PAYMENT_REQUEST_QUERY_KEY })
+      }
+    },
+  })
+
+  const processCapture = useCallback(
+    async ({ authorizationId, paymentRequestId, amount }: CaptureProps) => {
+      if (paymentRequestId) {
+        setPaymentRequestID(paymentRequestId)
+        const result = await mutation.mutateAsync({
+          authorizationId,
+          paymentRequestId,
+          amount,
+        })
+
+        if (result.success) {
+          return { error: undefined }
+        } else {
+          return { error: result.error }
+        }
+      }
+      return { error: undefined }
+    },
+    [mutation],
+  )
+
+  return { processCapture }
+}

--- a/src/hooks/usePaymentRequest.ts
+++ b/src/hooks/usePaymentRequest.ts
@@ -1,9 +1,7 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { ApiProps, usePaymentRequestProps, usePaymentRequestsProps } from '../types/props'
+import { ApiResponse, PaymentRequest, PaymentRequestPageResponse } from '../types'
 import { PaymentRequestClient } from '../clients'
-import { formatApiResponse } from '../types'
-import { ApiResponse, PaymentRequest } from '../types/ApiResponses'
-import { ApiProps, usePaymentRequestProps } from '../types/props'
-import { useQuery } from '@tanstack/react-query'
-
 const fetchPaymentRequest = async (
   apiUrl: string,
   paymentRequestId?: string,
@@ -11,22 +9,85 @@ const fetchPaymentRequest = async (
   authToken?: string,
 ): Promise<ApiResponse<PaymentRequest>> => {
   const client = new PaymentRequestClient({ apiUrl, authToken })
-  const response = await client.get({ paymentRequestId, merchantId })
-
+  const includeEvents = true
+  const response = await client.get({ paymentRequestId, includeEvents, merchantId })
   return response
 }
 
 export const usePaymentRequest = (
-  { paymentRequestId, merchantId }: usePaymentRequestProps,
+  {
+    merchantId,
+    statusSortDirection,
+    createdSortDirection,
+    contactSortDirection,
+    amountSortDirection,
+    pageNumber,
+    pageSize,
+    fromDateMS,
+    toDateMS,
+    status,
+    search,
+    currency,
+    minAmount,
+    maxAmount,
+    tags,
+  }: usePaymentRequestsProps,
+  { paymentRequestId }: usePaymentRequestProps,
   { apiUrl, authToken }: ApiProps,
 ) => {
-  const QUERY_KEY = ['PaymentRequest', merchantId, paymentRequestId, apiUrl, authToken]
+  const queryClient = useQueryClient()
+  const PAYMENT_REQUESTS_QUERY_KEY = [
+    'PaymentRequests',
+    apiUrl,
+    authToken,
+    merchantId,
+    statusSortDirection,
+    createdSortDirection,
+    contactSortDirection,
+    amountSortDirection,
+    pageNumber,
+    pageSize,
+    fromDateMS,
+    toDateMS,
+    status,
+    search,
+    currency,
+    minAmount,
+    maxAmount,
+    tags,
+  ]
+  const SINGLE_PAYMENT_REQUEST_QUERY_KEY = [
+    'PaymentRequest',
+    merchantId,
+    paymentRequestId,
+    apiUrl,
+    authToken,
+  ]
 
-  return useQuery<ApiResponse<PaymentRequest>, Error>(
-    QUERY_KEY,
-    () => fetchPaymentRequest(apiUrl, paymentRequestId, merchantId, authToken),
-    {
-      enabled: !!paymentRequestId && !!merchantId,
+  return useQuery<ApiResponse<PaymentRequest>, Error>({
+    queryKey: SINGLE_PAYMENT_REQUEST_QUERY_KEY,
+    queryFn: () => fetchPaymentRequest(apiUrl, paymentRequestId, merchantId, authToken),
+    enabled: !!paymentRequestId && !!merchantId,
+    placeholderData: () => {
+      if (paymentRequestId) {
+        const result: ApiResponse<PaymentRequestPageResponse> | undefined =
+          queryClient.getQueryData<ApiResponse<PaymentRequestPageResponse>>(
+            PAYMENT_REQUESTS_QUERY_KEY,
+          )
+        if (result?.status === 'success') {
+          const paymentRequest: PaymentRequest | undefined = result.data.content.find(
+            (x) => x.id === paymentRequestId,
+          )
+          if (paymentRequest) {
+            const apiresponse: ApiResponse<PaymentRequest> = {
+              data: paymentRequest,
+              status: 'success',
+              timestamp: new Date(),
+            }
+            return apiresponse
+          }
+        }
+      }
     },
-  )
+  })
 }

--- a/src/hooks/useRefund.ts
+++ b/src/hooks/useRefund.ts
@@ -1,8 +1,8 @@
-import { useCallback } from 'react'
-import { PaymentRequestClient } from '../clients'
-import { ApiError } from '../types/ApiResponses'
-import { ApiProps, RefundProps, usePaymentRequestsProps } from '../types/props'
+import { useCallback, useState } from 'react'
 import { UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query'
+import { ApiError } from '../types'
+import { PaymentRequestClient } from '../clients'
+import { ApiProps, RefundProps, usePaymentRequestsProps } from '../types/props'
 
 const refund = async (
   apiUrl: string,
@@ -44,7 +44,31 @@ export const useRefund = (
 } => {
   const queryClient = useQueryClient()
 
-  const QUERY_KEY = [
+  const [paymentRequestID, setPaymentRequestID] = useState<string>()
+
+  const SINGLE_PAYMENT_REQUEST_QUERY_KEY = [
+    'PaymentRequest',
+    merchantId,
+    paymentRequestID,
+    apiUrl,
+    authToken,
+  ]
+
+  const METRICS_QUERY_KEY = [
+    'PaymentRequestMetrics',
+    apiUrl,
+    authToken,
+    currency,
+    fromDateMS,
+    toDateMS,
+    maxAmount,
+    merchantId,
+    minAmount,
+    search,
+    tags,
+  ]
+
+  const PAYMENT_REQUESTS_QUERY_KEY = [
     'PaymentRequests',
     apiUrl,
     authToken,
@@ -81,7 +105,11 @@ export const useRefund = (
       ),
     onSuccess: (data: { success?: boolean | undefined; error?: ApiError | undefined }) => {
       if (data.success) {
-        queryClient.invalidateQueries({ queryKey: QUERY_KEY })
+        // After refund is successful, invalidate the payment requests cache, the single payment request cache,
+        // and the metrics cache because the status of the payment request has changed
+        queryClient.invalidateQueries({ queryKey: PAYMENT_REQUESTS_QUERY_KEY })
+        queryClient.invalidateQueries({ queryKey: SINGLE_PAYMENT_REQUEST_QUERY_KEY })
+        queryClient.invalidateQueries({ queryKey: METRICS_QUERY_KEY })
       }
     },
   })
@@ -89,6 +117,7 @@ export const useRefund = (
   const processRefund = useCallback(
     async ({ authorizationId, paymentRequestId, amount }: RefundProps) => {
       if (paymentRequestId) {
+        setPaymentRequestID(paymentRequestId)
         const result = await mutation.mutateAsync({
           authorizationId,
           paymentRequestId,

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -83,3 +83,9 @@ export interface RefundProps {
   paymentRequestId: string
   amount?: number
 }
+
+export interface CaptureProps {
+  authorizationId: string
+  paymentRequestId: string
+  amount?: number
+}


### PR DESCRIPTION
- Update usePaymentRequest to get placeholder data from already existing cached collection of payment requests.
- React query returns the existing PR object with placeholder data and then gets the latest in background.
- Updated useRefund to invalidate single payment request and metrics.